### PR TITLE
Back-ticks hide STDOUT and STDERR from the user

### DIFF
--- a/lib/procman/app.rb
+++ b/lib/procman/app.rb
@@ -70,7 +70,7 @@ module Procman
 
     def execute(command)
       log.debug "Running #{command.inspect}"
-      `#{command}`
+      system(command)
     end
   end
 end


### PR DESCRIPTION
Which means any foreman errors get hidden.
