### PR TITLE
Provide a means for creating a separator-separated list instead of just an array

### DIFF
--- a/lib/procman/app.rb
+++ b/lib/procman/app.rb
@@ -95,7 +95,7 @@ module Procman
       procs = YAML.load_file(@config[:procfile])
       monitoring = read_procfile_monitoring
 
-      output = { "procman-monitors" => export_monitoring_procs(procs, monitoring) }
+      output = { "procman_monitors" => export_monitoring_procs(procs, monitoring) }
 
       log.debug "Writing monitoring facter file to #{@monitoring_facter_file.inspect}"
       open(@monitoring_facter_file, 'w') {|f| YAML.dump(output, f) }

--- a/lib/procman/app.rb
+++ b/lib/procman/app.rb
@@ -15,11 +15,12 @@ module Procman
       log.debug "Procman options = #{config.inspect}"
 
       @config = config
-      @target_dir = @procfile_monitoring = @monitoring_facter_file = nil
+      @target_dir = @procfile_monitoring = @monitoring_facter_file = @monitoring_facter_file_sep = nil
 
       @config.delete(:target_dir).tap {|v| @target_dir = v if v && !v.empty? }
       @config.delete(:procfile_monitoring).tap {|v| @procfile_monitoring = v if v && !v.empty? }
       @config.delete(:monitoring_facter_file).tap {|v| @monitoring_facter_file = v if v && !v.empty? }
+      @config.delete(:monitoring_facter_file_sep).tap {|v| @monitoring_facter_file_sep = v if v && !v.empty? }
 
       fail(ArgumentError, "No $TARGET_DIR provided") unless @target_dir
     end
@@ -95,7 +96,11 @@ module Procman
       procs = YAML.load_file(@config[:procfile])
       monitoring = read_procfile_monitoring
 
-      output = { "procman_monitors" => export_monitoring_procs(procs, monitoring) }
+      # It seems that some config's of Facter stringify the array (e.g. when stringify_facts is enabled)
+      # so we want to be able to provide a separated-list:
+      proc_list = export_monitoring_procs(procs, monitoring)
+      proc_list = proc_list.join(@monitoring_facter_file_sep) if @monitoring_facter_file_sep && !@monitoring_facter_file_sep.empty?
+      output = { "procman_monitors" => proc_list }
 
       log.debug "Writing monitoring facter file to #{@monitoring_facter_file.inspect}"
       open(@monitoring_facter_file, 'w') {|f| YAML.dump(output, f) }

--- a/lib/procman/commandline.rb
+++ b/lib/procman/commandline.rb
@@ -64,7 +64,12 @@ module Procman
     option :monitoring_facter_file,
            long:        '--monitoring_out MONITORING_FILE',
            description: 'Change the file for exporting to a Monitoring YAML (Structure Fact) file.'
-           # default:     '/etc/facter/facts.d/procman'   #TODO: Is this more-appropriate?
+           # default:     '/etc/facter/facts.d/procman.yaml'   #TODO: Is this more-appropriate?
+
+    option :monitoring_facter_file_sep,
+           long:        '--monitoring_separator MONITORING_PROCESS_SEP',
+           description: 'Instead of providing an array, provide a list of items in a string, separated by MONITORING_PROCESS_SEP',
+           default:     '|'
 
     # rubocop:enable Metrics/LineLength
 

--- a/lib/procman/version.rb
+++ b/lib/procman/version.rb
@@ -1,4 +1,4 @@
 # Procman
 module Procman
-  VERSION = '0.9.9'
+  VERSION = '0.9.10'
 end

--- a/lib/procman/version.rb
+++ b/lib/procman/version.rb
@@ -1,4 +1,4 @@
 # Procman
 module Procman
-  VERSION = '0.9.10'
+  VERSION = '0.9.11'
 end


### PR DESCRIPTION
For the case where the Puppet version / config has `stringify_facts` enabled, therefore doesn't pass Arrays through from external fact files.
